### PR TITLE
Fix/linting molecule

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -5,39 +5,33 @@
   gather_facts: yes
 
   tasks:
-  # Update the apt cache as it's potentialy outdated in the container
-  - name: Update apt
-    ansible.builtin.shell:  # noqa: command-instead-of-module
-      cmd: apt-get update && apt-get upgrade -y
-    when: ansible_distribution == 'Ubuntu'
+    - name: Install git
+      ansible.builtin.package:
+        name:
+          - 'git'
+          - 'python3-pip'
 
-  - name: Install git
-    ansible.builtin.package:
-      name:
-        - 'git'
-        - 'python3-pip'
+    - name: Install ansible
+      ansible.builtin.shell:  # noqa: command-instead-of-module
+        cmd: python3 -m pip install ansible>2.12
+      changed_when: false
 
-  - name: Install ansible
-    ansible.builtin.shell:  # noqa: command-instead-of-module
-      cmd: python3 -m pip install ansible>2.12
-    changed_when: false
+    - name: Checkout potos playbook
+      ansible.builtin.git:
+        repo: 'https://github.com/projectpotos/ansible-plays-potos.git'
+        dest: '/potos'
+        version: 'main'
 
-  - name: Checkout potos playbook
-    ansible.builtin.git:
-      repo: 'https://github.com/projectpotos/ansible-plays-potos.git'
-      dest: '/potos'
-      version: 'main'
+    - name: Create repo place
+      ansible.builtin.file:
+        path: '/potos/specs'
+        state: directory
+        recurse: yes
 
-  - name: Create repo place
-    ansible.builtin.file:
-      path: '/potos/specs'
-      state: directory
-      recurse: yes
-
-  - name: Copy repo to container
-    ansible.builtin.copy:
-      src: '{{ (playbook_dir, "../../") | path_join }}'
-      dest: '/potos/specs/'
-      owner: root
-      group: root
-      mode: '0766'
+    - name: Copy repo to container
+      ansible.builtin.copy:
+        src: '{{ (playbook_dir, "../../") | path_join }}'
+        dest: '/potos/specs/'
+        owner: root
+        group: root
+        mode: '0766'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,7 @@ ansible>=2.12
 # Required for testing
 ansible-lint[yamllint]
 molecule[docker, lint]
-molecule-docker
+
+docker~=6.0.1
+molecule~=4.0.4
+molecule-docker~=2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ansible>=2.12
 # Required for testing
 ansible-lint[yamllint]
 molecule[docker, lint]
+molecule-docker


### PR DESCRIPTION
## Description

this should fix all the molecule related issues that happens, when forking this repository (or use as a template copy)

- linting (spaces)
- remove apt update in prepare.yml, not required as the testing images are built weekly
- add molecule-docker in requirements.txt
